### PR TITLE
update RT 5.0 to 5.0.4

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -8,10 +8,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /usr/local/src
 # hadolint ignore=DL3003,SC2174
-RUN curl -fsSL "https://download.bestpractical.com/pub/rt/release/rt-5.0.3.tar.gz" -o rt.tar.gz \
-  && echo "e23aee3cb291ccad5e521aeabe0fcd2f076bcfa8b7f801af498a7505e53d8441  rt.tar.gz" | sha256sum -c \
+RUN curl -fsSL "https://download.bestpractical.com/pub/rt/release/rt-5.0.4.tar.gz" -o rt.tar.gz \
+  && echo "916d870d22d92027f843798be6f880aaf1517aebc3f6ab25f456f4e772f4834d  rt.tar.gz" | sha256sum -c \
   && tar -xzf rt.tar.gz \
-  && cd rt-5.0.3 \
+  && cd rt-5.0.4 \
   && ./configure \
     --enable-developer \
     --enable-externalauth \

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -21,6 +21,8 @@ RUN curl -fsSL "https://download.bestpractical.com/pub/rt/release/rt-5.0.4.tar.g
     --enable-smime \
     --with-db-type=SQLite \
     --with-web-handler=standalone \
+  && /usr/bin/perl -MCPAN -e shell \
+  && make fixdeps \
   && make install \
   && mkdir --mode=0600 --parents /opt/rt5/var/data/{gpg,smime} \
   && make initialize-database \

--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 declare -A versions=(
   [4.2.17]='177b7e004b90ec7faaac8e21e11b7bc33bd129aba2d512e4b011c37995f8480c'
   [4.4.6]='1eff5bd9e556b5d6682ccd0e5b2f3dcc2c49a9ec4e215dadb90c4caf5e435e9e'
-  [5.0.3]='e23aee3cb291ccad5e521aeabe0fcd2f076bcfa8b7f801af498a7505e53d8441'
+  [5.0.4]='916d870d22d92027f843798be6f880aaf1517aebc3f6ab25f456f4e772f4834d'
 )
 
 for version in "${!versions[@]}"; do


### PR DESCRIPTION
Tiny PR to bump RT to the latest version 5.0.4

I had to add a *make fixdeps* as RT 5.0.4 requires new packages / updates. After that the container builds fine and works.