### PR TITLE
Add RT_WEB_DOMAIN RT_REDIRECT_URLS RT_DEFAULT_PASSWORD

### DIFF
--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -28,6 +28,7 @@ RUN curl -fsSL "https://download.bestpractical.com/pub/rt/release/rt-5.0.5.tar.g
 
 WORKDIR /opt/rt5
 COPY RT_SiteConfig.pm etc/
+COPY rt-passwd-from-env sbin/
 
 VOLUME /opt/rt5
 

--- a/5.0/RT_SiteConfig.pm
+++ b/5.0/RT_SiteConfig.pm
@@ -2,5 +2,7 @@ use utf8;
 
 Set($WebPort, RT_WEB_PORT);
 Set($MailCommand, "testfile");
+Set($WebDomain, "RT_WEB_DOMAIN");
+Set($CanonicalizeRedirectURLs, RT_REDIRECT_URLS);
 
 1;

--- a/5.0/docker-entrypoint.sh
+++ b/5.0/docker-entrypoint.sh
@@ -3,7 +3,16 @@
 set -euo pipefail
 
 : "${RT_WEB_PORT:=80}"
+: "${RT_WEB_DOMAIN:=localhost}"
+: "${RT_REDIRECT_URLS:=0}"
 
 sed -i "s/RT_WEB_PORT/$RT_WEB_PORT/" /opt/rt5/etc/RT_SiteConfig.pm
+sed -i "s/RT_WEB_DOMAIN/$RT_WEB_DOMAIN/" /opt/rt5/etc/RT_SiteConfig.pm
+sed -i "s/RT_REDIRECT_URLS/$RT_REDIRECT_URLS/" /opt/rt5/etc/RT_SiteConfig.pm
+
+if [ -n "${RT_DEFAULT_PASSWORD}" ]; then
+    /opt/rt5/sbin/rt-passwd-from-env
+fi
+
 
 exec "$@"

--- a/5.0/rt-passwd-from-env
+++ b/5.0/rt-passwd-from-env
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+# fix lib paths, some may be relative
+BEGIN { # BEGIN RT CMD BOILERPLATE
+    require File::Spec;
+    require Cwd;
+    my @libs = ("lib", "local/lib");
+    my $bin_path;
+
+    for my $lib (@libs) {
+        unless ( File::Spec->file_name_is_absolute($lib) ) {
+            $bin_path ||= ( File::Spec->splitpath(Cwd::abs_path(__FILE__)) )[1];
+            $lib = File::Spec->catfile( $bin_path, File::Spec->updir, $lib );
+        }
+        unshift @INC, $lib;
+    }
+
+}
+
+use RT;
+use RT::User;
+
+RT::Init();
+
+my $user = RT::User->new( RT->SystemUser );
+my ($ret, $msg) = $user->Load("root");
+
+$ret || die "Can't load user: $msg\n";
+
+my $username = $user->Name;
+my $password = $ENV{'RT_DEFAULT_PASSWORD'};
+die "RT_DEFAULT_PASSWORD environment variable is not set" unless defined $password;
+
+($ret, $msg) = $user->SetPassword($password);
+print "\n";
+
+die "Couldn't change password for user $username: $msg\n" unless $ret;
+
+print "Successfully changed password for user $username.\n";

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -28,6 +28,7 @@ RUN curl -fsSL "https://download.bestpractical.com/pub/rt/%%RT_RELEASE%%/rt-%%RT
 
 WORKDIR /opt/rt%%RT_VERSION_MAJOR%%
 COPY RT_SiteConfig.pm etc/
+COPY rt-passwd-from-env sbin/
 
 VOLUME /opt/rt%%RT_VERSION_MAJOR%%
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ docker run -d --name rt -p 8080:8080 -e RT_WEB_PORT=8080 ghcr.io/netsandbox/requ
 
 Then, access it via `http://localhost:8080` or `http://host-ip:8080` in a browser.
 
+
+### Advanced Options
+
+If you want to use it behind a reverse proxy under another domain as localhost
+
+Set `RT_WEB_DOMAIN` to your domain and set `RT_REDIRECT_URLS` to `1`
+
+You can set another root password with `RT_DEFAULT_PASSWORD`
+
+Example
+
+```shell
+docker run -d --name rt -e RT_WEB_DOMAIN=rt -e RT_WEB_PORT=8888 -e RT_REDIRECT_URLS=1 -e RT_DEFAULT_PASSWORD=12345 -p 8888:8888 netsandbox/request-tracker:5.0
+```
+
+
 ## RT Extension Testing
 
 You can use these Docker images to test your RT Extensions.

--- a/RT_SiteConfig.pm
+++ b/RT_SiteConfig.pm
@@ -2,5 +2,7 @@ use utf8;
 
 Set($WebPort, RT_WEB_PORT);
 Set($MailCommand, "testfile");
+Set($WebDomain, "RT_WEB_DOMAIN");
+Set($CanonicalizeRedirectURLs, RT_REDIRECT_URLS);
 
 1;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,7 +3,17 @@
 set -euo pipefail
 
 : "${RT_WEB_PORT:=80}"
+: "${RT_WEB_DOMAIN:=localhost}"
+: "${RT_REDIRECT_URLS:=0}"
 
 sed -i "s/RT_WEB_PORT/$RT_WEB_PORT/" /opt/rt%%RT_VERSION_MAJOR%%/etc/RT_SiteConfig.pm
+sed -i "s/RT_WEB_DOMAIN/$RT_WEB_DOMAIN/" /opt/rt%%RT_VERSION_MAJOR%%/etc/RT_SiteConfig.pm
+sed -i "s/RT_REDIRECT_URLS/$RT_REDIRECT_URLS/" /opt/rt%%RT_VERSION_MAJOR%%/etc/RT_SiteConfig.pm
+
+if [ -n "${RT_DEFAULT_PASSWORD}" ]; then
+    /opt/rt%%RT_VERSION_MAJOR%%/sbin/rt-passwd-from-env
+fi
+
+
 
 exec "$@"

--- a/rt-passwd-from-env
+++ b/rt-passwd-from-env
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use utf8;
+
+# fix lib paths, some may be relative
+BEGIN { # BEGIN RT CMD BOILERPLATE
+    require File::Spec;
+    require Cwd;
+    my @libs = ("lib", "local/lib");
+    my $bin_path;
+
+    for my $lib (@libs) {
+        unless ( File::Spec->file_name_is_absolute($lib) ) {
+            $bin_path ||= ( File::Spec->splitpath(Cwd::abs_path(__FILE__)) )[1];
+            $lib = File::Spec->catfile( $bin_path, File::Spec->updir, $lib );
+        }
+        unshift @INC, $lib;
+    }
+
+}
+
+use RT;
+use RT::User;
+
+RT::Init();
+
+my $user = RT::User->new( RT->SystemUser );
+my ($ret, $msg) = $user->Load("root");
+
+$ret || die "Can't load user: $msg\n";
+
+my $username = $user->Name;
+my $password = $ENV{'RT_DEFAULT_PASSWORD'};
+die "RT_DEFAULT_PASSWORD environment variable is not set" unless defined $password;
+
+($ret, $msg) = $user->SetPassword($password);
+print "\n";
+
+die "Couldn't change password for user $username: $msg\n" unless $ret;
+
+print "Successfully changed password for user $username.\n";

--- a/update.sh
+++ b/update.sh
@@ -15,6 +15,7 @@ for version in "${!versions[@]}"; do
 
   cp docker-entrypoint.sh RT_SiteConfig.pm "$version_major_minor"
   cp Dockerfile.template "$version_major_minor"/Dockerfile
+  cp rt-passwd-from-env "$version_major_minor"/rt-passwd-from-env
 
   if [[ "$version_major_minor" == '4.2' ]]; then
     # RT 4.2 does not support --enable-externalauth


### PR DESCRIPTION
All the default values set are from upstream, so if no additional env vars are passed, the behavior should stay unchanged.

* Add support to set default password from ENV
* Add support to set $WebDomain
* Add support to set $CanonicalizeRedirectURLs
